### PR TITLE
Clone response before reading body in err hook

### DIFF
--- a/src/fetch-api.ts
+++ b/src/fetch-api.ts
@@ -28,7 +28,7 @@ export function createApiInstance(opts: {
           const { response } = error;
           if (response && response.body) {
             try {
-              const body = await response.json();
+              const body = await response.clone().json();
               if (body.error) {
                 return new OpenAIApiError(body.error.message, {
                   status: response.status,


### PR DESCRIPTION
As per https://github.com/sindresorhus/ky/issues/479 the response object
should be cloned before it's read in the error hook.

This may fix #4 but needs to be verified.
