### PR TITLE
feat: support pass through fetch options

### DIFF
--- a/src/fetch-api.ts
+++ b/src/fetch-api.ts
@@ -4,6 +4,10 @@ import { OpenAIApiError } from './errors';
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 
+export interface FetchOptions extends Options {
+  credentials?: string;
+}
+
 /**
  * Create an instance of Ky with options shared by all requests.
  */
@@ -11,7 +15,7 @@ export function createApiInstance(opts: {
   apiKey: string;
   baseUrl?: string;
   organizationId?: string;
-  options?: Options;
+  fetchOptions?: FetchOptions;
 }) {
   return ky.extend({
     prefixUrl: opts.baseUrl || DEFAULT_BASE_URL,
@@ -23,7 +27,7 @@ export function createApiInstance(opts: {
         'OpenAI-Organization': opts.organizationId,
       }),
     },
-    ...opts.options,
+    ...opts.fetchOptions,
     hooks: {
       beforeError: [
         // @ts-ignore

--- a/src/fetch-api.ts
+++ b/src/fetch-api.ts
@@ -1,4 +1,5 @@
 import ky from 'ky';
+import type { Options } from 'ky';
 import { OpenAIApiError } from './errors';
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
@@ -10,6 +11,7 @@ export function createApiInstance(opts: {
   apiKey: string;
   baseUrl?: string;
   organizationId?: string;
+  options?: Options;
 }) {
   return ky.extend({
     prefixUrl: opts.baseUrl || DEFAULT_BASE_URL,
@@ -21,6 +23,7 @@ export function createApiInstance(opts: {
         'OpenAI-Organization': opts.organizationId,
       }),
     },
+    ...opts.options,
     hooks: {
       beforeError: [
         // @ts-ignore

--- a/src/openai-client.ts
+++ b/src/openai-client.ts
@@ -8,6 +8,7 @@ import type {
 } from './schemas/completion';
 import type { EditParams, EditResponse } from './schemas/edit';
 import type { EmbeddingParams, EmbeddingResponse } from './schemas/embedding';
+import type { Options } from 'ky';
 
 export type ConfigOpts = {
   /**
@@ -25,6 +26,8 @@ export type ConfigOpts = {
    * @see https://beta.openai.com/docs/api-reference/requesting-organization
    */
   organizationId?: string;
+
+  options?: Options;
 };
 
 export class OpenAIClient {
@@ -39,6 +42,7 @@ export class OpenAIClient {
     this.api = createApiInstance({
       apiKey,
       organizationId: opts.organizationId,
+      options: opts.options,
     });
   }
 

--- a/src/openai-client.ts
+++ b/src/openai-client.ts
@@ -8,7 +8,7 @@ import type {
 } from './schemas/completion';
 import type { EditParams, EditResponse } from './schemas/edit';
 import type { EmbeddingParams, EmbeddingResponse } from './schemas/embedding';
-import type { Options } from 'ky';
+import type { FetchOptions } from './fetch-api';
 
 export type ConfigOpts = {
   /**
@@ -27,7 +27,7 @@ export type ConfigOpts = {
    */
   organizationId?: string;
 
-  options?: Options;
+  fetchOptions?: FetchOptions;
 };
 
 export class OpenAIClient {
@@ -42,7 +42,7 @@ export class OpenAIClient {
     this.api = createApiInstance({
       apiKey,
       organizationId: opts.organizationId,
-      options: opts.options,
+      fetchOptions: opts.fetchOptions,
     });
   }
 


### PR DESCRIPTION
close: https://github.com/rileytomasek/openai-fetch/issues/8

Now you can use `fetchOptions` to diable `credentials`: 
```ts
    const openai = new OpenAIClient({
      apiKey: bot.env.OPENAI_API_KEY,
      fetchOptions: {
        credentials: undefined,
      },
    });
```

now it works on CloudFlare Workers(have tested) , it actually overrided the `ky` request params:
<img width="1057" alt="CleanShot 2023-01-18 at 12 53 29@2x" src="https://user-images.githubusercontent.com/13938334/213102566-e44d7525-c8f9-4935-8676-392a148489ce.png">
