### PR TITLE
Fixed the baseUrl option not working problem

### DIFF
--- a/src/openai-client.ts
+++ b/src/openai-client.ts
@@ -48,6 +48,7 @@ export class OpenAIClient {
       );
     this.api = createApiInstance({
       apiKey,
+      baseUrl: opts.baseUrl,
       organizationId: opts.organizationId,
       fetchOptions: opts.fetchOptions,
     });


### PR DESCRIPTION
Hi, @rileytomasek 

Changing the `baseUrl` is excellent for when you want to [cache stuff with a proxy](https://github.com/6/openai-caching-proxy-worker).
I noticed it wasn't working, so I made this PR to fix it.
I hope this helps, and I want to say I like the work you've done in this repo 😄 