### PR TITLE
Safe usage of "process.env"

### DIFF
--- a/src/openai-client.ts
+++ b/src/openai-client.ts
@@ -58,6 +58,7 @@ export class OpenAIClient {
   api: ReturnType<typeof createApiInstance>;
 
   constructor(opts: ConfigOpts = {}) {
+    const process = globalThis.process || { env: {} };
     const apiKey = opts.apiKey || process.env.OPENAI_API_KEY;
     const organizationId = opts.organizationId || process.env.OPENAI_ORG_ID;
     if (!apiKey)


### PR DESCRIPTION
This pull-request prevents error on attempt to use `process.env` on alternative environments while keeping compatibility with previous versions, to fix #24 