### PR TITLE
Fix absolute import in openai-types

### DIFF
--- a/openai-types/index.d.ts
+++ b/openai-types/index.d.ts
@@ -3,7 +3,7 @@ import * as Pagination from "./pagination.js";
 import * as Errors from "./error.js";
 import { type Agent } from "./_shims/index.js";
 import * as Uploads from "./uploads.js";
-import * as API from 'openai/resources/index';
+import * as API from './resources/index.js';
 export interface ClientOptions {
     /**
      * Defaults to process.env['OPENAI_API_KEY'].


### PR DESCRIPTION
Without this change, `openai-fetch` requires `openai` to be in the dependency tree.

Really this is a bug in the `openai` node package that looks to be auto-generated and happens to work in a weird, self-referential manner, but this workaround should unblock us for `llm-tools`.

Opened https://github.com/openai/openai-node/issues/415 to track the underlying issue in `openai`.