### PR TITLE
v2 remove all absolute imports from openai-types and package.json scripts cleanup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-openai-types
-dist

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+openai-types
+dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "root": true,
-  "extends": ["@dexaai/eslint-config", "@dexaai/eslint-config/node"],
-  "rules": {
-    "no-console": "off",
-    "no-process-env": "off"
-  }
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
+  "root": true,
   "extends": ["@dexaai/eslint-config", "@dexaai/eslint-config/node"],
-  "ignorePatterns": ["node_modules/", "dist/", "openai-types/"],
   "rules": {
     "no-console": "off",
     "no-process-env": "off"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,33 +1,23 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
-  lint:
-    name: Lint
+  test:
+    name: Test Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version:
+          - 21
+          - 20
+          - 18
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: yarn lint
-  types:
-    name: Types
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-      - run: yarn install --frozen-lockfile
-      - run: yarn typecheck
+      - run: yarn test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+openai-types
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/extract-types.mjs
+++ b/extract-types.mjs
@@ -20,10 +20,13 @@ function extractTypes(srcDir, destDir) {
     if (entry.isDirectory()) {
       extractTypes(srcPath, destPath);
     } else if (entry.isFile() && entry.name.endsWith('.d.ts')) {
-      // OpenAI has some absolute package imports, so switch them to use relative imports via TS path mapping.
+      const depth = Math.max(0, destPath.split('/').length - 2);
+      const relativePath = depth > 0 ? '../'.repeat(depth) : './';
+
+      // OpenAI has some absolute package imports, so switch them to use relative imports.
       const content = fs
         .readFileSync(srcPath, 'utf8')
-        .replaceAll(/'openai\/([^'.]*)'/g, "'~/openai-types/$1.js'");
+        .replaceAll(/'openai\/([^'.]*)'/g, `'${relativePath}$1.js'`);
       fs.writeFileSync(destPath, content);
       console.log(destPath);
     }

--- a/extract-types.mjs
+++ b/extract-types.mjs
@@ -1,12 +1,12 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 /**
  * This is used to extract the type declarations from the openai Node.js
  * package. Doing this allows it to be a devDependency instead of a dependency,
  * which greatly reduces the size of the final bundle.
  */
-function extractTypes(srcDir, destDir, root = false) {
+function extractTypes(srcDir, destDir) {
   if (!fs.existsSync(destDir)) {
     fs.mkdirSync(destDir, { recursive: true });
   }
@@ -20,20 +20,14 @@ function extractTypes(srcDir, destDir, root = false) {
     if (entry.isDirectory()) {
       extractTypes(srcPath, destPath);
     } else if (entry.isFile() && entry.name.endsWith('.d.ts')) {
+      // OpenAI has some absolute package imports, so switch them to use relative imports via TS path mapping.
+      const content = fs
+        .readFileSync(srcPath, 'utf8')
+        .replaceAll(/'openai\/([^'.]*)'/g, "'~/openai-types/$1.js'");
+      fs.writeFileSync(destPath, content);
       console.log(destPath);
-
-      if (root && entry.name === 'index.d.ts') {
-        // OpenAI has one line with an absolute package import, so switch it to
-        // be a relative import.
-        const content = fs
-          .readFileSync(srcPath, 'utf8')
-          .replaceAll("'openai/resources/index'", "'./resources/index.js'");
-        fs.writeFileSync(destPath, content);
-      } else {
-        fs.copyFileSync(srcPath, destPath);
-      }
     }
   }
 }
 
-extractTypes('node_modules/openai', 'openai-types', true);
+extractTypes('node_modules/openai', 'openai-types');

--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Riley Tomasek
+Copyright (c) 2023 Riley Tomasek
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/openai-types/_shims/index.d.ts
+++ b/openai-types/_shims/index.d.ts
@@ -2,7 +2,7 @@
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */
 import { manual } from "./manual-types.js";
-import * as auto from '~/openai-types/_shims/auto/types.js';
+import * as auto from '../_shims/auto/types.js';
 import { type RequestOptions } from "../core.js";
 
 type SelectType<Manual, Auto> = unknown extends Manual ? Auto : Manual;

--- a/openai-types/_shims/index.d.ts
+++ b/openai-types/_shims/index.d.ts
@@ -2,7 +2,7 @@
  * Disclaimer: modules in _shims aren't intended to be imported by SDK users.
  */
 import { manual } from "./manual-types.js";
-import * as auto from 'openai/_shims/auto/types';
+import * as auto from '~/openai-types/_shims/auto/types.js';
 import { type RequestOptions } from "../core.js";
 
 type SelectType<Manual, Auto> = unknown extends Manual ? Auto : Manual;

--- a/openai-types/_shims/manual-types.d.ts
+++ b/openai-types/_shims/manual-types.d.ts
@@ -4,8 +4,8 @@
 /**
  * Types will get added to this namespace when you import one of the following:
  *
- *   import 'openai/shims/node'
- *   import 'openai/shims/web'
+ *   import '~/openai-types/shims/node.js'
+ *   import '~/openai-types/shims/web.js'
  *
  * Importing more than one will cause type and runtime errors.
  */

--- a/openai-types/_shims/manual-types.d.ts
+++ b/openai-types/_shims/manual-types.d.ts
@@ -4,8 +4,8 @@
 /**
  * Types will get added to this namespace when you import one of the following:
  *
- *   import '~/openai-types/shims/node.js'
- *   import '~/openai-types/shims/web.js'
+ *   import '../shims/node.js'
+ *   import '../shims/web.js'
  *
  * Importing more than one will cause type and runtime errors.
  */

--- a/openai-types/core.d.ts
+++ b/openai-types/core.d.ts
@@ -32,8 +32,8 @@ export declare class APIPromise<T> extends Promise<T> {
      * 👋 Getting the wrong TypeScript type for `Response`?
      * Try setting `"moduleResolution": "NodeNext"` if you can,
      * or add one of these imports before your first `import … from 'openai'`:
-     * - `import 'openai/shims/node'` (if you're running on Node)
-     * - `import 'openai/shims/web'` (otherwise)
+     * - `import '~/openai-types/shims/node.js'` (if you're running on Node)
+     * - `import '~/openai-types/shims/web.js'` (otherwise)
      */
     asResponse(): Promise<Response>;
     /**
@@ -46,8 +46,8 @@ export declare class APIPromise<T> extends Promise<T> {
      * 👋 Getting the wrong TypeScript type for `Response`?
      * Try setting `"moduleResolution": "NodeNext"` if you can,
      * or add one of these imports before your first `import … from 'openai'`:
-     * - `import 'openai/shims/node'` (if you're running on Node)
-     * - `import 'openai/shims/web'` (otherwise)
+     * - `import '~/openai-types/shims/node.js'` (if you're running on Node)
+     * - `import '~/openai-types/shims/web.js'` (otherwise)
      */
     withResponse(): Promise<{
         data: T;

--- a/openai-types/core.d.ts
+++ b/openai-types/core.d.ts
@@ -32,8 +32,8 @@ export declare class APIPromise<T> extends Promise<T> {
      * 👋 Getting the wrong TypeScript type for `Response`?
      * Try setting `"moduleResolution": "NodeNext"` if you can,
      * or add one of these imports before your first `import … from 'openai'`:
-     * - `import '~/openai-types/shims/node.js'` (if you're running on Node)
-     * - `import '~/openai-types/shims/web.js'` (otherwise)
+     * - `import './shims/node.js'` (if you're running on Node)
+     * - `import './shims/web.js'` (otherwise)
      */
     asResponse(): Promise<Response>;
     /**
@@ -46,8 +46,8 @@ export declare class APIPromise<T> extends Promise<T> {
      * 👋 Getting the wrong TypeScript type for `Response`?
      * Try setting `"moduleResolution": "NodeNext"` if you can,
      * or add one of these imports before your first `import … from 'openai'`:
-     * - `import '~/openai-types/shims/node.js'` (if you're running on Node)
-     * - `import '~/openai-types/shims/web.js'` (otherwise)
+     * - `import './shims/node.js'` (if you're running on Node)
+     * - `import './shims/web.js'` (otherwise)
      */
     withResponse(): Promise<{
         data: T;

--- a/openai-types/index.d.ts
+++ b/openai-types/index.d.ts
@@ -3,7 +3,7 @@ import * as Pagination from "./pagination.js";
 import * as Errors from "./error.js";
 import { type Agent } from "./_shims/index.js";
 import * as Uploads from "./uploads.js";
-import * as API from '~/openai-types/resources/index.js';
+import * as API from './resources/index.js';
 export interface ClientOptions {
     /**
      * Defaults to process.env['OPENAI_API_KEY'].

--- a/openai-types/index.d.ts
+++ b/openai-types/index.d.ts
@@ -3,7 +3,7 @@ import * as Pagination from "./pagination.js";
 import * as Errors from "./error.js";
 import { type Agent } from "./_shims/index.js";
 import * as Uploads from "./uploads.js";
-import * as API from './resources/index.js';
+import * as API from '~/openai-types/resources/index.js';
 export interface ClientOptions {
     /**
      * Defaults to process.env['OPENAI_API_KEY'].

--- a/openai-types/lib/AbstractChatCompletionRunner.d.ts
+++ b/openai-types/lib/AbstractChatCompletionRunner.d.ts
@@ -1,8 +1,8 @@
                               
-import * as Core from '~/openai-types/core.js';
-import { type CompletionUsage } from '~/openai-types/resources/completions.js';
-import { type Completions, type ChatCompletion, type ChatCompletionMessage, type ChatCompletionMessageParam, type ChatCompletionCreateParams } from '~/openai-types/resources/chat/completions.js';
-import { APIUserAbortError, OpenAIError } from '~/openai-types/error.js';
+import * as Core from '../core.js';
+import { type CompletionUsage } from '../resources/completions.js';
+import { type Completions, type ChatCompletion, type ChatCompletionMessage, type ChatCompletionMessageParam, type ChatCompletionCreateParams } from '../resources/chat/completions.js';
+import { APIUserAbortError, OpenAIError } from '../error.js';
 import { type BaseFunctionsArgs } from "./RunnableFunction.js";
 import { ChatCompletionFunctionRunnerParams, ChatCompletionToolRunnerParams } from "./ChatCompletionRunner.js";
 import { ChatCompletionStreamingFunctionRunnerParams, ChatCompletionStreamingToolRunnerParams } from "./ChatCompletionStreamingRunner.js";

--- a/openai-types/lib/AbstractChatCompletionRunner.d.ts
+++ b/openai-types/lib/AbstractChatCompletionRunner.d.ts
@@ -1,8 +1,8 @@
                               
-import * as Core from 'openai/core';
-import { type CompletionUsage } from 'openai/resources/completions';
-import { type Completions, type ChatCompletion, type ChatCompletionMessage, type ChatCompletionMessageParam, type ChatCompletionCreateParams } from 'openai/resources/chat/completions';
-import { APIUserAbortError, OpenAIError } from 'openai/error';
+import * as Core from '~/openai-types/core.js';
+import { type CompletionUsage } from '~/openai-types/resources/completions.js';
+import { type Completions, type ChatCompletion, type ChatCompletionMessage, type ChatCompletionMessageParam, type ChatCompletionCreateParams } from '~/openai-types/resources/chat/completions.js';
+import { APIUserAbortError, OpenAIError } from '~/openai-types/error.js';
 import { type BaseFunctionsArgs } from "./RunnableFunction.js";
 import { ChatCompletionFunctionRunnerParams, ChatCompletionToolRunnerParams } from "./ChatCompletionRunner.js";
 import { ChatCompletionStreamingFunctionRunnerParams, ChatCompletionStreamingToolRunnerParams } from "./ChatCompletionStreamingRunner.js";

--- a/openai-types/lib/ChatCompletionRunner.d.ts
+++ b/openai-types/lib/ChatCompletionRunner.d.ts
@@ -1,4 +1,4 @@
-import { type Completions, type ChatCompletionMessageParam, type ChatCompletionCreateParamsNonStreaming } from '~/openai-types/resources/chat/completions.js';
+import { type Completions, type ChatCompletionMessageParam, type ChatCompletionCreateParamsNonStreaming } from '../resources/chat/completions.js';
 import { type RunnableFunctions, type BaseFunctionsArgs, RunnableTools } from "./RunnableFunction.js";
 import { AbstractChatCompletionRunner, AbstractChatCompletionRunnerEvents, RunnerOptions } from "./AbstractChatCompletionRunner.js";
 export interface ChatCompletionRunnerEvents extends AbstractChatCompletionRunnerEvents {

--- a/openai-types/lib/ChatCompletionRunner.d.ts
+++ b/openai-types/lib/ChatCompletionRunner.d.ts
@@ -1,4 +1,4 @@
-import { type Completions, type ChatCompletionMessageParam, type ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions';
+import { type Completions, type ChatCompletionMessageParam, type ChatCompletionCreateParamsNonStreaming } from '~/openai-types/resources/chat/completions.js';
 import { type RunnableFunctions, type BaseFunctionsArgs, RunnableTools } from "./RunnableFunction.js";
 import { AbstractChatCompletionRunner, AbstractChatCompletionRunnerEvents, RunnerOptions } from "./AbstractChatCompletionRunner.js";
 export interface ChatCompletionRunnerEvents extends AbstractChatCompletionRunnerEvents {

--- a/openai-types/lib/ChatCompletionStream.d.ts
+++ b/openai-types/lib/ChatCompletionStream.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { Completions, type ChatCompletion, type ChatCompletionChunk, type ChatCompletionCreateParams, type ChatCompletionCreateParamsBase } from 'openai/resources/chat/completions';
+import * as Core from '~/openai-types/core.js';
+import { Completions, type ChatCompletion, type ChatCompletionChunk, type ChatCompletionCreateParams, type ChatCompletionCreateParamsBase } from '~/openai-types/resources/chat/completions.js';
 import { AbstractChatCompletionRunner, type AbstractChatCompletionRunnerEvents } from "./AbstractChatCompletionRunner.js";
-import { type ReadableStream } from 'openai/_shims/index';
+import { type ReadableStream } from '~/openai-types/_shims/index.js';
 export interface ChatCompletionStreamEvents extends AbstractChatCompletionRunnerEvents {
     content: (contentDelta: string, contentSnapshot: string) => void;
     chunk: (chunk: ChatCompletionChunk, snapshot: ChatCompletionSnapshot) => void;

--- a/openai-types/lib/ChatCompletionStream.d.ts
+++ b/openai-types/lib/ChatCompletionStream.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { Completions, type ChatCompletion, type ChatCompletionChunk, type ChatCompletionCreateParams, type ChatCompletionCreateParamsBase } from '~/openai-types/resources/chat/completions.js';
+import * as Core from '../core.js';
+import { Completions, type ChatCompletion, type ChatCompletionChunk, type ChatCompletionCreateParams, type ChatCompletionCreateParamsBase } from '../resources/chat/completions.js';
 import { AbstractChatCompletionRunner, type AbstractChatCompletionRunnerEvents } from "./AbstractChatCompletionRunner.js";
-import { type ReadableStream } from '~/openai-types/_shims/index.js';
+import { type ReadableStream } from '../_shims/index.js';
 export interface ChatCompletionStreamEvents extends AbstractChatCompletionRunnerEvents {
     content: (contentDelta: string, contentSnapshot: string) => void;
     chunk: (chunk: ChatCompletionChunk, snapshot: ChatCompletionSnapshot) => void;

--- a/openai-types/lib/ChatCompletionStreamingRunner.d.ts
+++ b/openai-types/lib/ChatCompletionStreamingRunner.d.ts
@@ -1,6 +1,6 @@
-import { Completions, type ChatCompletionChunk, type ChatCompletionCreateParamsStreaming } from '~/openai-types/resources/chat/completions.js';
+import { Completions, type ChatCompletionChunk, type ChatCompletionCreateParamsStreaming } from '../resources/chat/completions.js';
 import { RunnerOptions, type AbstractChatCompletionRunnerEvents } from "./AbstractChatCompletionRunner.js";
-import { type ReadableStream } from '~/openai-types/_shims/index.js';
+import { type ReadableStream } from '../_shims/index.js';
 import { RunnableTools, type BaseFunctionsArgs, type RunnableFunctions } from "./RunnableFunction.js";
 import { ChatCompletionSnapshot, ChatCompletionStream } from "./ChatCompletionStream.js";
 export interface ChatCompletionStreamEvents extends AbstractChatCompletionRunnerEvents {

--- a/openai-types/lib/ChatCompletionStreamingRunner.d.ts
+++ b/openai-types/lib/ChatCompletionStreamingRunner.d.ts
@@ -1,6 +1,6 @@
-import { Completions, type ChatCompletionChunk, type ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions';
+import { Completions, type ChatCompletionChunk, type ChatCompletionCreateParamsStreaming } from '~/openai-types/resources/chat/completions.js';
 import { RunnerOptions, type AbstractChatCompletionRunnerEvents } from "./AbstractChatCompletionRunner.js";
-import { type ReadableStream } from 'openai/_shims/index';
+import { type ReadableStream } from '~/openai-types/_shims/index.js';
 import { RunnableTools, type BaseFunctionsArgs, type RunnableFunctions } from "./RunnableFunction.js";
 import { ChatCompletionSnapshot, ChatCompletionStream } from "./ChatCompletionStream.js";
 export interface ChatCompletionStreamEvents extends AbstractChatCompletionRunnerEvents {

--- a/openai-types/lib/chatCompletionUtils.d.ts
+++ b/openai-types/lib/chatCompletionUtils.d.ts
@@ -1,4 +1,4 @@
-import { type ChatCompletionAssistantMessageParam, type ChatCompletionFunctionMessageParam, type ChatCompletionMessageParam, type ChatCompletionToolMessageParam } from 'openai/resources';
+import { type ChatCompletionAssistantMessageParam, type ChatCompletionFunctionMessageParam, type ChatCompletionMessageParam, type ChatCompletionToolMessageParam } from '~/openai-types/resources.js';
 export declare const isAssistantMessage: (message: ChatCompletionMessageParam | null | undefined) => message is ChatCompletionAssistantMessageParam;
 export declare const isFunctionMessage: (message: ChatCompletionMessageParam | null | undefined) => message is ChatCompletionFunctionMessageParam;
 export declare const isToolMessage: (message: ChatCompletionMessageParam | null | undefined) => message is ChatCompletionToolMessageParam;

--- a/openai-types/lib/chatCompletionUtils.d.ts
+++ b/openai-types/lib/chatCompletionUtils.d.ts
@@ -1,4 +1,4 @@
-import { type ChatCompletionAssistantMessageParam, type ChatCompletionFunctionMessageParam, type ChatCompletionMessageParam, type ChatCompletionToolMessageParam } from '~/openai-types/resources.js';
+import { type ChatCompletionAssistantMessageParam, type ChatCompletionFunctionMessageParam, type ChatCompletionMessageParam, type ChatCompletionToolMessageParam } from '../resources.js';
 export declare const isAssistantMessage: (message: ChatCompletionMessageParam | null | undefined) => message is ChatCompletionAssistantMessageParam;
 export declare const isFunctionMessage: (message: ChatCompletionMessageParam | null | undefined) => message is ChatCompletionFunctionMessageParam;
 export declare const isToolMessage: (message: ChatCompletionMessageParam | null | undefined) => message is ChatCompletionToolMessageParam;

--- a/openai-types/resources/audio/audio.d.ts
+++ b/openai-types/resources/audio/audio.d.ts
@@ -1,7 +1,7 @@
-import { APIResource } from 'openai/resource';
-import * as SpeechAPI from 'openai/resources/audio/speech';
-import * as TranscriptionsAPI from 'openai/resources/audio/transcriptions';
-import * as TranslationsAPI from 'openai/resources/audio/translations';
+import { APIResource } from '~/openai-types/resource.js';
+import * as SpeechAPI from '~/openai-types/resources/audio/speech.js';
+import * as TranscriptionsAPI from '~/openai-types/resources/audio/transcriptions.js';
+import * as TranslationsAPI from '~/openai-types/resources/audio/translations.js';
 export declare class Audio extends APIResource {
     transcriptions: TranscriptionsAPI.Transcriptions;
     translations: TranslationsAPI.Translations;

--- a/openai-types/resources/audio/audio.d.ts
+++ b/openai-types/resources/audio/audio.d.ts
@@ -1,7 +1,7 @@
-import { APIResource } from '~/openai-types/resource.js';
-import * as SpeechAPI from '~/openai-types/resources/audio/speech.js';
-import * as TranscriptionsAPI from '~/openai-types/resources/audio/transcriptions.js';
-import * as TranslationsAPI from '~/openai-types/resources/audio/translations.js';
+import { APIResource } from '../../resource.js';
+import * as SpeechAPI from '../../resources/audio/speech.js';
+import * as TranscriptionsAPI from '../../resources/audio/transcriptions.js';
+import * as TranslationsAPI from '../../resources/audio/translations.js';
 export declare class Audio extends APIResource {
     transcriptions: TranscriptionsAPI.Transcriptions;
     translations: TranslationsAPI.Translations;

--- a/openai-types/resources/audio/speech.d.ts
+++ b/openai-types/resources/audio/speech.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import { type Response } from '~/openai-types/_shims/index.js';
-import * as SpeechAPI from '~/openai-types/resources/audio/speech.js';
+import * as Core from '../../core.js';
+import { APIResource } from '../../resource.js';
+import { type Response } from '../../_shims/index.js';
+import * as SpeechAPI from '../../resources/audio/speech.js';
 export declare class Speech extends APIResource {
     /**
      * Generates audio from the input text.

--- a/openai-types/resources/audio/speech.d.ts
+++ b/openai-types/resources/audio/speech.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import { type Response } from 'openai/_shims/index';
-import * as SpeechAPI from 'openai/resources/audio/speech';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import { type Response } from '~/openai-types/_shims/index.js';
+import * as SpeechAPI from '~/openai-types/resources/audio/speech.js';
 export declare class Speech extends APIResource {
     /**
      * Generates audio from the input text.

--- a/openai-types/resources/audio/transcriptions.d.ts
+++ b/openai-types/resources/audio/transcriptions.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as TranscriptionsAPI from 'openai/resources/audio/transcriptions';
-import { type Uploadable } from 'openai/core';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as TranscriptionsAPI from '~/openai-types/resources/audio/transcriptions.js';
+import { type Uploadable } from '~/openai-types/core.js';
 export declare class Transcriptions extends APIResource {
     /**
      * Transcribes audio into the input language.

--- a/openai-types/resources/audio/transcriptions.d.ts
+++ b/openai-types/resources/audio/transcriptions.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as TranscriptionsAPI from '~/openai-types/resources/audio/transcriptions.js';
-import { type Uploadable } from '~/openai-types/core.js';
+import * as Core from '../../core.js';
+import { APIResource } from '../../resource.js';
+import * as TranscriptionsAPI from '../../resources/audio/transcriptions.js';
+import { type Uploadable } from '../../core.js';
 export declare class Transcriptions extends APIResource {
     /**
      * Transcribes audio into the input language.

--- a/openai-types/resources/audio/translations.d.ts
+++ b/openai-types/resources/audio/translations.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as TranslationsAPI from '~/openai-types/resources/audio/translations.js';
-import { type Uploadable } from '~/openai-types/core.js';
+import * as Core from '../../core.js';
+import { APIResource } from '../../resource.js';
+import * as TranslationsAPI from '../../resources/audio/translations.js';
+import { type Uploadable } from '../../core.js';
 export declare class Translations extends APIResource {
     /**
      * Translates audio into English.

--- a/openai-types/resources/audio/translations.d.ts
+++ b/openai-types/resources/audio/translations.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as TranslationsAPI from 'openai/resources/audio/translations';
-import { type Uploadable } from 'openai/core';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as TranslationsAPI from '~/openai-types/resources/audio/translations.js';
+import { type Uploadable } from '~/openai-types/core.js';
 export declare class Translations extends APIResource {
     /**
      * Translates audio into English.

--- a/openai-types/resources/beta/assistants/assistants.d.ts
+++ b/openai-types/resources/beta/assistants/assistants.d.ts
@@ -1,8 +1,8 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as AssistantsAPI from 'openai/resources/beta/assistants/assistants';
-import * as FilesAPI from 'openai/resources/beta/assistants/files';
-import { CursorPage, type CursorPageParams } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as AssistantsAPI from '~/openai-types/resources/beta/assistants/assistants.js';
+import * as FilesAPI from '~/openai-types/resources/beta/assistants/files.js';
+import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
 export declare class Assistants extends APIResource {
     files: FilesAPI.Files;
     /**

--- a/openai-types/resources/beta/assistants/assistants.d.ts
+++ b/openai-types/resources/beta/assistants/assistants.d.ts
@@ -1,8 +1,8 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as AssistantsAPI from '~/openai-types/resources/beta/assistants/assistants.js';
-import * as FilesAPI from '~/openai-types/resources/beta/assistants/files.js';
-import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
+import * as Core from '../../../core.js';
+import { APIResource } from '../../../resource.js';
+import * as AssistantsAPI from '../../../resources/beta/assistants/assistants.js';
+import * as FilesAPI from '../../../resources/beta/assistants/files.js';
+import { CursorPage, type CursorPageParams } from '../../../pagination.js';
 export declare class Assistants extends APIResource {
     files: FilesAPI.Files;
     /**

--- a/openai-types/resources/beta/assistants/files.d.ts
+++ b/openai-types/resources/beta/assistants/files.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as FilesAPI from 'openai/resources/beta/assistants/files';
-import { CursorPage, type CursorPageParams } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as FilesAPI from '~/openai-types/resources/beta/assistants/files.js';
+import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
 export declare class Files extends APIResource {
     /**
      * Create an assistant file by attaching a

--- a/openai-types/resources/beta/assistants/files.d.ts
+++ b/openai-types/resources/beta/assistants/files.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as FilesAPI from '~/openai-types/resources/beta/assistants/files.js';
-import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
+import * as Core from '../../../core.js';
+import { APIResource } from '../../../resource.js';
+import * as FilesAPI from '../../../resources/beta/assistants/files.js';
+import { CursorPage, type CursorPageParams } from '../../../pagination.js';
 export declare class Files extends APIResource {
     /**
      * Create an assistant file by attaching a

--- a/openai-types/resources/beta/beta.d.ts
+++ b/openai-types/resources/beta/beta.d.ts
@@ -1,7 +1,7 @@
-import { APIResource } from '~/openai-types/resource.js';
-import * as AssistantsAPI from '~/openai-types/resources/beta/assistants/assistants.js';
-import * as ChatAPI from '~/openai-types/resources/beta/chat/chat.js';
-import * as ThreadsAPI from '~/openai-types/resources/beta/threads/threads.js';
+import { APIResource } from '../../resource.js';
+import * as AssistantsAPI from '../../resources/beta/assistants/assistants.js';
+import * as ChatAPI from '../../resources/beta/chat/chat.js';
+import * as ThreadsAPI from '../../resources/beta/threads/threads.js';
 export declare class Beta extends APIResource {
     chat: ChatAPI.Chat;
     assistants: AssistantsAPI.Assistants;

--- a/openai-types/resources/beta/beta.d.ts
+++ b/openai-types/resources/beta/beta.d.ts
@@ -1,7 +1,7 @@
-import { APIResource } from 'openai/resource';
-import * as AssistantsAPI from 'openai/resources/beta/assistants/assistants';
-import * as ChatAPI from 'openai/resources/beta/chat/chat';
-import * as ThreadsAPI from 'openai/resources/beta/threads/threads';
+import { APIResource } from '~/openai-types/resource.js';
+import * as AssistantsAPI from '~/openai-types/resources/beta/assistants/assistants.js';
+import * as ChatAPI from '~/openai-types/resources/beta/chat/chat.js';
+import * as ThreadsAPI from '~/openai-types/resources/beta/threads/threads.js';
 export declare class Beta extends APIResource {
     chat: ChatAPI.Chat;
     assistants: AssistantsAPI.Assistants;

--- a/openai-types/resources/beta/chat/chat.d.ts
+++ b/openai-types/resources/beta/chat/chat.d.ts
@@ -1,5 +1,5 @@
-import { APIResource } from '~/openai-types/resource.js';
-import * as CompletionsAPI from '~/openai-types/resources/beta/chat/completions.js';
+import { APIResource } from '../../../resource.js';
+import * as CompletionsAPI from '../../../resources/beta/chat/completions.js';
 export declare class Chat extends APIResource {
     completions: CompletionsAPI.Completions;
 }

--- a/openai-types/resources/beta/chat/chat.d.ts
+++ b/openai-types/resources/beta/chat/chat.d.ts
@@ -1,5 +1,5 @@
-import { APIResource } from 'openai/resource';
-import * as CompletionsAPI from 'openai/resources/beta/chat/completions';
+import { APIResource } from '~/openai-types/resource.js';
+import * as CompletionsAPI from '~/openai-types/resources/beta/chat/completions.js';
 export declare class Chat extends APIResource {
     completions: CompletionsAPI.Completions;
 }

--- a/openai-types/resources/beta/chat/completions.d.ts
+++ b/openai-types/resources/beta/chat/completions.d.ts
@@ -1,17 +1,17 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
-export { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
-import { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
-export { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams, } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
-import { BaseFunctionsArgs } from '~/openai-types/lib/RunnableFunction.js';
-export { RunnableFunction, RunnableFunctions, RunnableFunctionWithParse, RunnableFunctionWithoutParse, ParsingFunction, } from '~/openai-types/lib/RunnableFunction.js';
-import { ChatCompletionToolRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
-export { ChatCompletionToolRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
-import { ChatCompletionStreamingToolRunnerParams } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
-export { ChatCompletionStreamingToolRunnerParams } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
-import { ChatCompletionStream, type ChatCompletionStreamParams } from '~/openai-types/lib/ChatCompletionStream.js';
-export { ChatCompletionStream, type ChatCompletionStreamParams } from '~/openai-types/lib/ChatCompletionStream.js';
+import * as Core from '../../../core.js';
+import { APIResource } from '../../../resource.js';
+import { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from '../../../lib/ChatCompletionRunner.js';
+export { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from '../../../lib/ChatCompletionRunner.js';
+import { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams } from '../../../lib/ChatCompletionStreamingRunner.js';
+export { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams, } from '../../../lib/ChatCompletionStreamingRunner.js';
+import { BaseFunctionsArgs } from '../../../lib/RunnableFunction.js';
+export { RunnableFunction, RunnableFunctions, RunnableFunctionWithParse, RunnableFunctionWithoutParse, ParsingFunction, } from '../../../lib/RunnableFunction.js';
+import { ChatCompletionToolRunnerParams } from '../../../lib/ChatCompletionRunner.js';
+export { ChatCompletionToolRunnerParams } from '../../../lib/ChatCompletionRunner.js';
+import { ChatCompletionStreamingToolRunnerParams } from '../../../lib/ChatCompletionStreamingRunner.js';
+export { ChatCompletionStreamingToolRunnerParams } from '../../../lib/ChatCompletionStreamingRunner.js';
+import { ChatCompletionStream, type ChatCompletionStreamParams } from '../../../lib/ChatCompletionStream.js';
+export { ChatCompletionStream, type ChatCompletionStreamParams } from '../../../lib/ChatCompletionStream.js';
 export declare class Completions extends APIResource {
     /**
      * A convenience helper for using function calls with the /chat/completions

--- a/openai-types/resources/beta/chat/completions.d.ts
+++ b/openai-types/resources/beta/chat/completions.d.ts
@@ -1,17 +1,17 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from 'openai/lib/ChatCompletionRunner';
-export { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from 'openai/lib/ChatCompletionRunner';
-import { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams } from 'openai/lib/ChatCompletionStreamingRunner';
-export { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams, } from 'openai/lib/ChatCompletionStreamingRunner';
-import { BaseFunctionsArgs } from 'openai/lib/RunnableFunction';
-export { RunnableFunction, RunnableFunctions, RunnableFunctionWithParse, RunnableFunctionWithoutParse, ParsingFunction, } from 'openai/lib/RunnableFunction';
-import { ChatCompletionToolRunnerParams } from 'openai/lib/ChatCompletionRunner';
-export { ChatCompletionToolRunnerParams } from 'openai/lib/ChatCompletionRunner';
-import { ChatCompletionStreamingToolRunnerParams } from 'openai/lib/ChatCompletionStreamingRunner';
-export { ChatCompletionStreamingToolRunnerParams } from 'openai/lib/ChatCompletionStreamingRunner';
-import { ChatCompletionStream, type ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
-export { ChatCompletionStream, type ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
+export { ChatCompletionRunner, ChatCompletionFunctionRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
+import { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
+export { ChatCompletionStreamingRunner, ChatCompletionStreamingFunctionRunnerParams, } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
+import { BaseFunctionsArgs } from '~/openai-types/lib/RunnableFunction.js';
+export { RunnableFunction, RunnableFunctions, RunnableFunctionWithParse, RunnableFunctionWithoutParse, ParsingFunction, } from '~/openai-types/lib/RunnableFunction.js';
+import { ChatCompletionToolRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
+export { ChatCompletionToolRunnerParams } from '~/openai-types/lib/ChatCompletionRunner.js';
+import { ChatCompletionStreamingToolRunnerParams } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
+export { ChatCompletionStreamingToolRunnerParams } from '~/openai-types/lib/ChatCompletionStreamingRunner.js';
+import { ChatCompletionStream, type ChatCompletionStreamParams } from '~/openai-types/lib/ChatCompletionStream.js';
+export { ChatCompletionStream, type ChatCompletionStreamParams } from '~/openai-types/lib/ChatCompletionStream.js';
 export declare class Completions extends APIResource {
     /**
      * A convenience helper for using function calls with the /chat/completions

--- a/openai-types/resources/beta/threads/messages/files.d.ts
+++ b/openai-types/resources/beta/threads/messages/files.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as FilesAPI from '~/openai-types/resources/beta/threads/messages/files.js';
-import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
+import * as Core from '../../../../core.js';
+import { APIResource } from '../../../../resource.js';
+import * as FilesAPI from '../../../../resources/beta/threads/messages/files.js';
+import { CursorPage, type CursorPageParams } from '../../../../pagination.js';
 export declare class Files extends APIResource {
     /**
      * Retrieves a message file.

--- a/openai-types/resources/beta/threads/messages/files.d.ts
+++ b/openai-types/resources/beta/threads/messages/files.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as FilesAPI from 'openai/resources/beta/threads/messages/files';
-import { CursorPage, type CursorPageParams } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as FilesAPI from '~/openai-types/resources/beta/threads/messages/files.js';
+import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
 export declare class Files extends APIResource {
     /**
      * Retrieves a message file.

--- a/openai-types/resources/beta/threads/messages/messages.d.ts
+++ b/openai-types/resources/beta/threads/messages/messages.d.ts
@@ -1,8 +1,8 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as MessagesAPI from '~/openai-types/resources/beta/threads/messages/messages.js';
-import * as FilesAPI from '~/openai-types/resources/beta/threads/messages/files.js';
-import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
+import * as Core from '../../../../core.js';
+import { APIResource } from '../../../../resource.js';
+import * as MessagesAPI from '../../../../resources/beta/threads/messages/messages.js';
+import * as FilesAPI from '../../../../resources/beta/threads/messages/files.js';
+import { CursorPage, type CursorPageParams } from '../../../../pagination.js';
 export declare class Messages extends APIResource {
     files: FilesAPI.Files;
     /**

--- a/openai-types/resources/beta/threads/messages/messages.d.ts
+++ b/openai-types/resources/beta/threads/messages/messages.d.ts
@@ -1,8 +1,8 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as MessagesAPI from 'openai/resources/beta/threads/messages/messages';
-import * as FilesAPI from 'openai/resources/beta/threads/messages/files';
-import { CursorPage, type CursorPageParams } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as MessagesAPI from '~/openai-types/resources/beta/threads/messages/messages.js';
+import * as FilesAPI from '~/openai-types/resources/beta/threads/messages/files.js';
+import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
 export declare class Messages extends APIResource {
     files: FilesAPI.Files;
     /**

--- a/openai-types/resources/beta/threads/runs/runs.d.ts
+++ b/openai-types/resources/beta/threads/runs/runs.d.ts
@@ -1,8 +1,8 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as RunsAPI from 'openai/resources/beta/threads/runs/runs';
-import * as StepsAPI from 'openai/resources/beta/threads/runs/steps';
-import { CursorPage, type CursorPageParams } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as RunsAPI from '~/openai-types/resources/beta/threads/runs/runs.js';
+import * as StepsAPI from '~/openai-types/resources/beta/threads/runs/steps.js';
+import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
 export declare class Runs extends APIResource {
     steps: StepsAPI.Steps;
     /**

--- a/openai-types/resources/beta/threads/runs/runs.d.ts
+++ b/openai-types/resources/beta/threads/runs/runs.d.ts
@@ -1,8 +1,8 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as RunsAPI from '~/openai-types/resources/beta/threads/runs/runs.js';
-import * as StepsAPI from '~/openai-types/resources/beta/threads/runs/steps.js';
-import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
+import * as Core from '../../../../core.js';
+import { APIResource } from '../../../../resource.js';
+import * as RunsAPI from '../../../../resources/beta/threads/runs/runs.js';
+import * as StepsAPI from '../../../../resources/beta/threads/runs/steps.js';
+import { CursorPage, type CursorPageParams } from '../../../../pagination.js';
 export declare class Runs extends APIResource {
     steps: StepsAPI.Steps;
     /**

--- a/openai-types/resources/beta/threads/runs/steps.d.ts
+++ b/openai-types/resources/beta/threads/runs/steps.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as StepsAPI from 'openai/resources/beta/threads/runs/steps';
-import { CursorPage, type CursorPageParams } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as StepsAPI from '~/openai-types/resources/beta/threads/runs/steps.js';
+import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
 export declare class Steps extends APIResource {
     /**
      * Retrieves a run step.

--- a/openai-types/resources/beta/threads/runs/steps.d.ts
+++ b/openai-types/resources/beta/threads/runs/steps.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as StepsAPI from '~/openai-types/resources/beta/threads/runs/steps.js';
-import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
+import * as Core from '../../../../core.js';
+import { APIResource } from '../../../../resource.js';
+import * as StepsAPI from '../../../../resources/beta/threads/runs/steps.js';
+import { CursorPage, type CursorPageParams } from '../../../../pagination.js';
 export declare class Steps extends APIResource {
     /**
      * Retrieves a run step.

--- a/openai-types/resources/beta/threads/threads.d.ts
+++ b/openai-types/resources/beta/threads/threads.d.ts
@@ -1,8 +1,8 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as ThreadsAPI from 'openai/resources/beta/threads/threads';
-import * as MessagesAPI from 'openai/resources/beta/threads/messages/messages';
-import * as RunsAPI from 'openai/resources/beta/threads/runs/runs';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as ThreadsAPI from '~/openai-types/resources/beta/threads/threads.js';
+import * as MessagesAPI from '~/openai-types/resources/beta/threads/messages/messages.js';
+import * as RunsAPI from '~/openai-types/resources/beta/threads/runs/runs.js';
 export declare class Threads extends APIResource {
     runs: RunsAPI.Runs;
     messages: MessagesAPI.Messages;

--- a/openai-types/resources/beta/threads/threads.d.ts
+++ b/openai-types/resources/beta/threads/threads.d.ts
@@ -1,8 +1,8 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as ThreadsAPI from '~/openai-types/resources/beta/threads/threads.js';
-import * as MessagesAPI from '~/openai-types/resources/beta/threads/messages/messages.js';
-import * as RunsAPI from '~/openai-types/resources/beta/threads/runs/runs.js';
+import * as Core from '../../../core.js';
+import { APIResource } from '../../../resource.js';
+import * as ThreadsAPI from '../../../resources/beta/threads/threads.js';
+import * as MessagesAPI from '../../../resources/beta/threads/messages/messages.js';
+import * as RunsAPI from '../../../resources/beta/threads/runs/runs.js';
 export declare class Threads extends APIResource {
     runs: RunsAPI.Runs;
     messages: MessagesAPI.Messages;

--- a/openai-types/resources/chat/chat.d.ts
+++ b/openai-types/resources/chat/chat.d.ts
@@ -1,5 +1,5 @@
-import { APIResource } from 'openai/resource';
-import * as CompletionsAPI from 'openai/resources/chat/completions';
+import { APIResource } from '~/openai-types/resource.js';
+import * as CompletionsAPI from '~/openai-types/resources/chat/completions.js';
 export declare class Chat extends APIResource {
     completions: CompletionsAPI.Completions;
 }

--- a/openai-types/resources/chat/chat.d.ts
+++ b/openai-types/resources/chat/chat.d.ts
@@ -1,5 +1,5 @@
-import { APIResource } from '~/openai-types/resource.js';
-import * as CompletionsAPI from '~/openai-types/resources/chat/completions.js';
+import { APIResource } from '../../resource.js';
+import * as CompletionsAPI from '../../resources/chat/completions.js';
 export declare class Chat extends APIResource {
     completions: CompletionsAPI.Completions;
 }

--- a/openai-types/resources/chat/completions.d.ts
+++ b/openai-types/resources/chat/completions.d.ts
@@ -1,9 +1,9 @@
-import * as Core from 'openai/core';
-import { APIPromise } from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as ChatCompletionsAPI from 'openai/resources/chat/completions';
-import * as CompletionsAPI from 'openai/resources/completions';
-import { Stream } from 'openai/streaming';
+import * as Core from '~/openai-types/core.js';
+import { APIPromise } from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as ChatCompletionsAPI from '~/openai-types/resources/chat/completions.js';
+import * as CompletionsAPI from '~/openai-types/resources/completions.js';
+import { Stream } from '~/openai-types/streaming.js';
 export declare class Completions extends APIResource {
     /**
      * Creates a model response for the given chat conversation.

--- a/openai-types/resources/chat/completions.d.ts
+++ b/openai-types/resources/chat/completions.d.ts
@@ -1,9 +1,9 @@
-import * as Core from '~/openai-types/core.js';
-import { APIPromise } from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as ChatCompletionsAPI from '~/openai-types/resources/chat/completions.js';
-import * as CompletionsAPI from '~/openai-types/resources/completions.js';
-import { Stream } from '~/openai-types/streaming.js';
+import * as Core from '../../core.js';
+import { APIPromise } from '../../core.js';
+import { APIResource } from '../../resource.js';
+import * as ChatCompletionsAPI from '../../resources/chat/completions.js';
+import * as CompletionsAPI from '../../resources/completions.js';
+import { Stream } from '../../streaming.js';
 export declare class Completions extends APIResource {
     /**
      * Creates a model response for the given chat conversation.

--- a/openai-types/resources/completions.d.ts
+++ b/openai-types/resources/completions.d.ts
@@ -1,8 +1,8 @@
-import * as Core from '~/openai-types/core.js';
-import { APIPromise } from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as CompletionsAPI from '~/openai-types/resources/completions.js';
-import { Stream } from '~/openai-types/streaming.js';
+import * as Core from '../core.js';
+import { APIPromise } from '../core.js';
+import { APIResource } from '../resource.js';
+import * as CompletionsAPI from '../resources/completions.js';
+import { Stream } from '../streaming.js';
 export declare class Completions extends APIResource {
     /**
      * Creates a completion for the provided prompt and parameters.

--- a/openai-types/resources/completions.d.ts
+++ b/openai-types/resources/completions.d.ts
@@ -1,8 +1,8 @@
-import * as Core from 'openai/core';
-import { APIPromise } from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as CompletionsAPI from 'openai/resources/completions';
-import { Stream } from 'openai/streaming';
+import * as Core from '~/openai-types/core.js';
+import { APIPromise } from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as CompletionsAPI from '~/openai-types/resources/completions.js';
+import { Stream } from '~/openai-types/streaming.js';
 export declare class Completions extends APIResource {
     /**
      * Creates a completion for the provided prompt and parameters.

--- a/openai-types/resources/edits.d.ts
+++ b/openai-types/resources/edits.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as EditsAPI from 'openai/resources/edits';
-import * as CompletionsAPI from 'openai/resources/completions';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as EditsAPI from '~/openai-types/resources/edits.js';
+import * as CompletionsAPI from '~/openai-types/resources/completions.js';
 export declare class Edits extends APIResource {
     /**
      * Creates a new edit for the provided input, instruction, and parameters.

--- a/openai-types/resources/edits.d.ts
+++ b/openai-types/resources/edits.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as EditsAPI from '~/openai-types/resources/edits.js';
-import * as CompletionsAPI from '~/openai-types/resources/completions.js';
+import * as Core from '../core.js';
+import { APIResource } from '../resource.js';
+import * as EditsAPI from '../resources/edits.js';
+import * as CompletionsAPI from '../resources/completions.js';
 export declare class Edits extends APIResource {
     /**
      * Creates a new edit for the provided input, instruction, and parameters.

--- a/openai-types/resources/embeddings.d.ts
+++ b/openai-types/resources/embeddings.d.ts
@@ -1,6 +1,6 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as EmbeddingsAPI from '~/openai-types/resources/embeddings.js';
+import * as Core from '../core.js';
+import { APIResource } from '../resource.js';
+import * as EmbeddingsAPI from '../resources/embeddings.js';
 export declare class Embeddings extends APIResource {
     /**
      * Creates an embedding vector representing the input text.

--- a/openai-types/resources/embeddings.d.ts
+++ b/openai-types/resources/embeddings.d.ts
@@ -1,6 +1,6 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as EmbeddingsAPI from 'openai/resources/embeddings';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as EmbeddingsAPI from '~/openai-types/resources/embeddings.js';
 export declare class Embeddings extends APIResource {
     /**
      * Creates an embedding vector representing the input text.

--- a/openai-types/resources/files.d.ts
+++ b/openai-types/resources/files.d.ts
@@ -1,8 +1,8 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as FilesAPI from 'openai/resources/files';
-import { type Uploadable } from 'openai/core';
-import { Page } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as FilesAPI from '~/openai-types/resources/files.js';
+import { type Uploadable } from '~/openai-types/core.js';
+import { Page } from '~/openai-types/pagination.js';
 export declare class Files extends APIResource {
     /**
      * Upload a file that can be used across various endpoints/features. The size of

--- a/openai-types/resources/files.d.ts
+++ b/openai-types/resources/files.d.ts
@@ -1,8 +1,8 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as FilesAPI from '~/openai-types/resources/files.js';
-import { type Uploadable } from '~/openai-types/core.js';
-import { Page } from '~/openai-types/pagination.js';
+import * as Core from '../core.js';
+import { APIResource } from '../resource.js';
+import * as FilesAPI from '../resources/files.js';
+import { type Uploadable } from '../core.js';
+import { Page } from '../pagination.js';
 export declare class Files extends APIResource {
     /**
      * Upload a file that can be used across various endpoints/features. The size of

--- a/openai-types/resources/fine-tunes.d.ts
+++ b/openai-types/resources/fine-tunes.d.ts
@@ -1,10 +1,10 @@
-import * as Core from 'openai/core';
-import { APIPromise } from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as FineTunesAPI from 'openai/resources/fine-tunes';
-import * as FilesAPI from 'openai/resources/files';
-import { Page } from 'openai/pagination';
-import { Stream } from 'openai/streaming';
+import * as Core from '~/openai-types/core.js';
+import { APIPromise } from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as FineTunesAPI from '~/openai-types/resources/fine-tunes.js';
+import * as FilesAPI from '~/openai-types/resources/files.js';
+import { Page } from '~/openai-types/pagination.js';
+import { Stream } from '~/openai-types/streaming.js';
 export declare class FineTunes extends APIResource {
     /**
      * Creates a job that fine-tunes a specified model from a given dataset.

--- a/openai-types/resources/fine-tunes.d.ts
+++ b/openai-types/resources/fine-tunes.d.ts
@@ -1,10 +1,10 @@
-import * as Core from '~/openai-types/core.js';
-import { APIPromise } from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as FineTunesAPI from '~/openai-types/resources/fine-tunes.js';
-import * as FilesAPI from '~/openai-types/resources/files.js';
-import { Page } from '~/openai-types/pagination.js';
-import { Stream } from '~/openai-types/streaming.js';
+import * as Core from '../core.js';
+import { APIPromise } from '../core.js';
+import { APIResource } from '../resource.js';
+import * as FineTunesAPI from '../resources/fine-tunes.js';
+import * as FilesAPI from '../resources/files.js';
+import { Page } from '../pagination.js';
+import { Stream } from '../streaming.js';
 export declare class FineTunes extends APIResource {
     /**
      * Creates a job that fine-tunes a specified model from a given dataset.

--- a/openai-types/resources/fine-tuning/fine-tuning.d.ts
+++ b/openai-types/resources/fine-tuning/fine-tuning.d.ts
@@ -1,5 +1,5 @@
-import { APIResource } from '~/openai-types/resource.js';
-import * as JobsAPI from '~/openai-types/resources/fine-tuning/jobs.js';
+import { APIResource } from '../../resource.js';
+import * as JobsAPI from '../../resources/fine-tuning/jobs.js';
 export declare class FineTuning extends APIResource {
     jobs: JobsAPI.Jobs;
 }

--- a/openai-types/resources/fine-tuning/fine-tuning.d.ts
+++ b/openai-types/resources/fine-tuning/fine-tuning.d.ts
@@ -1,5 +1,5 @@
-import { APIResource } from 'openai/resource';
-import * as JobsAPI from 'openai/resources/fine-tuning/jobs';
+import { APIResource } from '~/openai-types/resource.js';
+import * as JobsAPI from '~/openai-types/resources/fine-tuning/jobs.js';
 export declare class FineTuning extends APIResource {
     jobs: JobsAPI.Jobs;
 }

--- a/openai-types/resources/fine-tuning/jobs.d.ts
+++ b/openai-types/resources/fine-tuning/jobs.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as JobsAPI from 'openai/resources/fine-tuning/jobs';
-import { CursorPage, type CursorPageParams } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as JobsAPI from '~/openai-types/resources/fine-tuning/jobs.js';
+import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
 export declare class Jobs extends APIResource {
     /**
      * Creates a job that fine-tunes a specified model from a given dataset.

--- a/openai-types/resources/fine-tuning/jobs.d.ts
+++ b/openai-types/resources/fine-tuning/jobs.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as JobsAPI from '~/openai-types/resources/fine-tuning/jobs.js';
-import { CursorPage, type CursorPageParams } from '~/openai-types/pagination.js';
+import * as Core from '../../core.js';
+import { APIResource } from '../../resource.js';
+import * as JobsAPI from '../../resources/fine-tuning/jobs.js';
+import { CursorPage, type CursorPageParams } from '../../pagination.js';
 export declare class Jobs extends APIResource {
     /**
      * Creates a job that fine-tunes a specified model from a given dataset.

--- a/openai-types/resources/images.d.ts
+++ b/openai-types/resources/images.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as ImagesAPI from '~/openai-types/resources/images.js';
-import { type Uploadable } from '~/openai-types/core.js';
+import * as Core from '../core.js';
+import { APIResource } from '../resource.js';
+import * as ImagesAPI from '../resources/images.js';
+import { type Uploadable } from '../core.js';
 export declare class Images extends APIResource {
     /**
      * Creates a variation of a given image.

--- a/openai-types/resources/images.d.ts
+++ b/openai-types/resources/images.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as ImagesAPI from 'openai/resources/images';
-import { type Uploadable } from 'openai/core';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as ImagesAPI from '~/openai-types/resources/images.js';
+import { type Uploadable } from '~/openai-types/core.js';
 export declare class Images extends APIResource {
     /**
      * Creates a variation of a given image.

--- a/openai-types/resources/models.d.ts
+++ b/openai-types/resources/models.d.ts
@@ -1,7 +1,7 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as ModelsAPI from '~/openai-types/resources/models.js';
-import { Page } from '~/openai-types/pagination.js';
+import * as Core from '../core.js';
+import { APIResource } from '../resource.js';
+import * as ModelsAPI from '../resources/models.js';
+import { Page } from '../pagination.js';
 export declare class Models extends APIResource {
     /**
      * Retrieves a model instance, providing basic information about the model such as

--- a/openai-types/resources/models.d.ts
+++ b/openai-types/resources/models.d.ts
@@ -1,7 +1,7 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as ModelsAPI from 'openai/resources/models';
-import { Page } from 'openai/pagination';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as ModelsAPI from '~/openai-types/resources/models.js';
+import { Page } from '~/openai-types/pagination.js';
 export declare class Models extends APIResource {
     /**
      * Retrieves a model instance, providing basic information about the model such as

--- a/openai-types/resources/moderations.d.ts
+++ b/openai-types/resources/moderations.d.ts
@@ -1,6 +1,6 @@
-import * as Core from 'openai/core';
-import { APIResource } from 'openai/resource';
-import * as ModerationsAPI from 'openai/resources/moderations';
+import * as Core from '~/openai-types/core.js';
+import { APIResource } from '~/openai-types/resource.js';
+import * as ModerationsAPI from '~/openai-types/resources/moderations.js';
 export declare class Moderations extends APIResource {
     /**
      * Classifies if text violates OpenAI's Content Policy

--- a/openai-types/resources/moderations.d.ts
+++ b/openai-types/resources/moderations.d.ts
@@ -1,6 +1,6 @@
-import * as Core from '~/openai-types/core.js';
-import { APIResource } from '~/openai-types/resource.js';
-import * as ModerationsAPI from '~/openai-types/resources/moderations.js';
+import * as Core from '../core.js';
+import { APIResource } from '../resource.js';
+import * as ModerationsAPI from '../resources/moderations.js';
 export declare class Moderations extends APIResource {
     /**
      * Classifies if text violates OpenAI's Content Policy

--- a/openai-types/src/_shims/manual-types.d.ts
+++ b/openai-types/src/_shims/manual-types.d.ts
@@ -4,8 +4,8 @@
 /**
  * Types will get added to this namespace when you import one of the following:
  *
- *   import 'openai/shims/node'
- *   import 'openai/shims/web'
+ *   import '~/openai-types/shims/node.js'
+ *   import '~/openai-types/shims/web.js'
  *
  * Importing more than one will cause type and runtime errors.
  */

--- a/openai-types/src/_shims/manual-types.d.ts
+++ b/openai-types/src/_shims/manual-types.d.ts
@@ -4,8 +4,8 @@
 /**
  * Types will get added to this namespace when you import one of the following:
  *
- *   import '~/openai-types/shims/node.js'
- *   import '~/openai-types/shims/web.js'
+ *   import '../../shims/node.js'
+ *   import '../../shims/web.js'
  *
  * Importing more than one will cause type and runtime errors.
  */

--- a/package.json
+++ b/package.json
@@ -1,8 +1,18 @@
 {
   "name": "openai-fetch",
+  "type": "module",
   "version": "2.0.0-beta.8",
   "description": "OpenAI client powered by fetch",
-  "type": "module",
+  "repository": "dexaai/openai-fetch",
+  "license": "MIT",
+  "author": {
+    "name": "Riley Tomasek",
+    "email": "hi@rile.yt",
+    "url": "https://rile.yt"
+  },
+  "engines": {
+    "node": ">=18"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -12,31 +22,27 @@
   },
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
+  "sideEffects": false,
   "files": [
     "dist",
     "openai-types"
   ],
-  "repository": "dexaai/openai-fetch",
-  "author": {
-    "name": "Riley Tomasek",
-    "email": "hi@rile.yt",
-    "url": "https://rile.yt"
-  },
   "scripts": {
-    "prebuild": "yarn clean:build && yarn extract-types",
     "build": "tsc --project tsconfig.dist.json",
-    "clean": "rm -rf dist openai-types node_modules",
-    "clean:build": "rm -rf dist openai-types",
+    "prebuild": "run-s clean:build extract-types",
+    "clean": "rimraf dist openai-types node_modules",
+    "dev": "tsc --watch",
+    "clean:build": "rimraf dist openai-types",
     "extract-types": "node extract-types.mjs",
-    "format": "prettier --write \"src/**/*.{ts,tsx}\"",
-    "lint": "eslint src",
-    "prepare": "yarn build",
-    "prepublishOnly": "yarn lint && yarn typecheck",
+    "prepare": "run-s build",
+    "prepublishOnly": "run-s test",
     "release": "np",
-    "typecheck": "tsc --noEmit"
+    "pretest": "run-s build",
+    "test": "run-p test:*",
+    "test:lint": "eslint src",
+    "test:format": "prettier --check \"**/*.{js,ts,tsx}\"",
+    "test:typecheck": "tsc --noEmit"
   },
-  "license": "MIT",
-  "private": false,
   "dependencies": {
     "ky": "^1.1.0"
   },
@@ -44,17 +50,10 @@
     "@dexaai/eslint-config": "^0.4.0",
     "eslint": "^8.52.0",
     "np": "^8.0.4",
+    "npm-run-all": "^4.1.5",
     "openai": "^4.12.4",
     "prettier": "^3.0.3",
+    "rimraf": "^5.0.5",
     "typescript": "^5.2.2"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org"
-  },
-  "prettier": {
-    "singleQuote": true
-  },
-  "engines": {
-    "node": ">=18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "ky": "^1.1.0"
+    "ky": "^1.1.3"
   },
   "devDependencies": {
     "@dexaai/eslint-config": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,24 @@
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
     "typescript": "^5.2.2"
+  },
+  "prettier": {
+    "singleQuote": true
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+      "@dexaai/eslint-config",
+      "@dexaai/eslint-config/node"
+    ],
+    "ignorePatterns": [
+      "dist",
+      "node_modules",
+      "openai-types"
+    ],
+    "rules": {
+      "no-console": "off",
+      "no-process-env": "off"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-fetch",
   "type": "module",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "OpenAI client powered by fetch",
   "repository": "dexaai/openai-fetch",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,17 @@ Unfortunately, the official [openai-node](https://github.com/openai/openai-node)
 - Endpoints other than chat, completions, and embeddings
 - Aren't concerned with lib size or fetch patching
 
+## Install
+
+```bash
+npm install openai-fetch
+```
+
+This package requires `node >= 18` or an environment with `fetch` support.
+
+This package exports [ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). If your project uses CommonJS, consider switching to ESM or use the [dynamic `import()`](https://v8.dev/features/dynamic-import) function.
+
 ## Usage
-
-**Warning:** This package is native [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) and no longer provides a CommonJS export. If your project uses CommonJS, you will have to [convert to ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) or use the [dynamic `import()`](https://v8.dev/features/dynamic-import) function. Please don't open issues for questions regarding CommonJS / ESM.
-
-Install `openai-fetch` with your favorite package manager and create an instance of the `OpenAIClient` class.
 
 ```ts
 import { OpenAIClient } from 'openai-fetch';
@@ -58,3 +64,7 @@ client.createEmbeddings(params: EmbeddingParams): Promise<EmbeddingResponse>
 ### Type Definitions
 
 The type definitions are avaible through TSServer, and can be found here: [type definitions](/src/types.ts).
+
+## License
+
+MIT © [Dexa](https://dexa.ai)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     "noEmitOnError": true,
     "useDefineForClassFields": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,6 @@
     "noEmitOnError": true,
     "useDefineForClassFields": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "paths": {
-      "~/*": ["./src/*"]
-    }
+    "skipLibCheck": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,7 +3117,7 @@ keyv@^4.0.0, keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
-ky@^1.1.0:
+ky@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ky/-/ky-1.1.3.tgz#0d75906dfae00af0b4ea1a6fe29e505c4a0ee234"
   integrity sha512-t7q8sJfazzHbfYxiCtuLIH4P+pWoCgunDll17O/GBZBqMt2vHjGSx5HzSxhOc2BDEg3YN/EmeA7VKrHnwuWDag==

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,18 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz#e5211452df060fa8522b55c7b3c0c4d1981cb044"
   integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -422,6 +434,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@pnpm/config.env-replace@^1.1.0":
   version "1.1.0"
@@ -1298,7 +1315,18 @@ cosmiconfig@^8.1.3:
     parse-json "^5.2.0"
     path-type "^4.0.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2123,6 +2151,14 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+foreground-child@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
+  integrity sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^4.0.1"
+
 form-data-encoder@1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
@@ -2236,6 +2272,17 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
+glob@^10.3.7:
+  version "10.3.10"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
+  integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^2.3.5"
+    minimatch "^9.0.1"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+    path-scurry "^1.10.1"
+
 glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -2343,7 +2390,7 @@ graceful-fs@4.2.10:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
+graceful-fs@^4.1.2, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2410,6 +2457,11 @@ hasown@^2.0.0:
   integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
   dependencies:
     function-bind "^1.1.2"
+
+hosted-git-info@^2.1.4:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.1:
   version "4.1.0"
@@ -2985,6 +3037,15 @@ iterator.prototype@^1.1.2:
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
 
+jackspeak@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
+  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3006,6 +3067,11 @@ json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
@@ -3142,6 +3208,16 @@ listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -3251,6 +3327,11 @@ lru-cache@^7.5.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
+"lru-cache@^9.1.1 || ^10.0.0":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
+  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
+
 lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
@@ -3264,6 +3345,11 @@ md5@^2.3.0:
     charenc "0.0.2"
     crypt "0.0.2"
     is-buffer "~1.1.6"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==
 
 meow@^12.0.1:
   version "12.1.1"
@@ -3337,7 +3423,7 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^9.0.0:
+minimatch@^9.0.0, minimatch@^9.0.1:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
   integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
@@ -3348,6 +3434,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
+  integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3391,6 +3482,11 @@ new-github-release-url@^2.0.0:
   dependencies:
     type-fest "^2.5.1"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
 node-domexception@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
@@ -3407,6 +3503,16 @@ node-releases@^2.0.13:
   version "2.0.13"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
   integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
+
+normalize-package-data@^2.3.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
 
 normalize-package-data@^3.0.2:
   version "3.0.3"
@@ -3485,6 +3591,21 @@ npm-name@^7.1.0:
     registry-auth-token "^4.2.2"
     registry-url "^6.0.1"
     validate-npm-package-name "^3.0.0"
+
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^4.0.1:
   version "4.0.1"
@@ -3807,6 +3928,14 @@ parse-json-object@^2.0.1:
   dependencies:
     types-json "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -3832,6 +3961,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
+path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
+
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -3847,6 +3981,21 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.1.tgz#9ba6bf5aa8500fe9fd67df4f0d9483b2b0bfc698"
+  integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
+  dependencies:
+    lru-cache "^9.1.1 || ^10.0.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -3861,6 +4010,16 @@ picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -3991,6 +4150,15 @@ read-pkg-up@^9.1.0:
     read-pkg "^7.1.0"
     type-fest "^2.5.0"
 
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 read-pkg@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-7.1.0.tgz#438b4caed1ad656ba359b3e00fd094f3c427a43e"
@@ -4094,7 +4262,7 @@ resolve-pkg-maps@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
-resolve@^1.10.1, resolve@^1.22.1, resolve@^1.22.4:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.22.1, resolve@^1.22.4:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -4153,6 +4321,13 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.5.tgz#9be65d2d6e683447d2e9013da2bf451139a61ccf"
+  integrity sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==
+  dependencies:
+    glob "^10.3.7"
 
 run-applescript@^5.0.0:
   version "5.0.0"
@@ -4233,6 +4408,11 @@ semver-diff@^4.0.0:
   dependencies:
     semver "^7.3.5"
 
+"semver@2 || 3 || 4 || 5", semver@^5.5.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
 semver@^6.1.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -4264,6 +4444,13 @@ set-function-name@^2.0.0, set-function-name@^2.0.1:
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.0"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
+  dependencies:
+    shebang-regex "^1.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -4271,10 +4458,20 @@ shebang-command@^2.0.0:
   dependencies:
     shebang-regex "^3.0.0"
 
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
+
 shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.6.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
+  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -4289,6 +4486,11 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -4338,6 +4540,15 @@ stop-iteration-iterator@^1.0.0:
   dependencies:
     internal-slot "^1.0.4"
 
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -4354,15 +4565,6 @@ string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.1.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -4387,6 +4589,15 @@ string.prototype.matchall@^4.0.8:
     regexp.prototype.flags "^1.5.0"
     set-function-name "^2.0.0"
     side-channel "^1.0.4"
+
+string.prototype.padend@^3.0.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.5.tgz#311ef3a4e3c557dd999cdf88fbdde223f2ac0f95"
+  integrity sha512-DOB27b/2UTTD+4myKUFh+/fXWcu/UDyASIXfg+7VzoCNNGOfWvoyU/x5pvVHr++ztyt/oSYI1BcWBBG/hmlNjA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
 
 string.prototype.trim@^1.2.8:
   version "1.2.8"
@@ -4422,6 +4633,13 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -4442,13 +4660,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -4873,6 +5084,13 @@ which-typed-array@^1.1.11, which-typed-array@^1.1.13, which-typed-array@^1.1.9:
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
 
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -4886,6 +5104,15 @@ widest-line@^4.0.1:
   integrity sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==
   dependencies:
     string-width "^5.0.1"
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This PR makes many of the same changes to `package.json` as [dexter](https://github.com/dexaai/dexter) uses for consistency.

- improves github CI to run node 18, 20, 21
- `extract-types.mjs` now replaces all remaining absolute import paths in case they're referenced by a lesser-used codepath like in https://github.com/dexaai/openai-fetch/pull/36