### PR TITLE
fix: add signal to RequestOpts

### DIFF
--- a/src/openai-client.ts
+++ b/src/openai-client.ts
@@ -40,7 +40,10 @@ export type ConfigOpts = {
 };
 
 /** Override the default Ky options for a single request. */
-type RequestOpts = { headers?: KyOptions['headers'] };
+type RequestOpts = {
+  headers?: KyOptions['headers'];
+  signal?: AbortSignal
+};
 
 export class OpenAIClient {
   private api: ReturnType<typeof createApiInstance>;


### PR DESCRIPTION
You already can abort via a signal, but this just tells you that you can ;)