### PR TITLE
Add TTS support

### DIFF
--- a/openai-types/version.d.ts
+++ b/openai-types/version.d.ts
@@ -1,2 +1,2 @@
-export declare const VERSION = "4.67.0";
+export declare const VERSION = "4.67.1";
 //# sourceMappingURL=version.d.ts.map

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@dexaai/eslint-config": "^1.3.0",
     "eslint": "^8.57.0",
     "np": "^10.0.7",
-    "openai": "^4.67.0",
+    "openai": "^4.67.1",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "typescript": "^5.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^10.0.7
         version: 10.0.7(typescript@5.6.2)
       openai:
-        specifier: ^4.67.0
-        version: 4.67.0
+        specifier: ^4.67.1
+        version: 4.67.1
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -1601,8 +1601,8 @@ packages:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
     engines: {node: '>=18'}
 
-  openai@4.67.0:
-    resolution: {integrity: sha512-jdsPSEdZbUNVtvEFE/eeL4FjKavyVMJJEdGMZk9vExglqUrblEcFxi3LK2WhskhrYKAU1MgJAI+dK9pDcA5z5w==}
+  openai@4.67.1:
+    resolution: {integrity: sha512-2YbRFy6qaYRJabK2zLMn4txrB2xBy0KP5g/eoqeSPTT31mIJMnkT75toagvfE555IKa2RdrzJrZwdDsUipsAMw==}
     hasBin: true
     peerDependencies:
       zod: ^3.23.8
@@ -4093,7 +4093,7 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openai@4.67.0:
+  openai@4.67.1:
     dependencies:
       '@types/node': 18.19.54
       '@types/node-fetch': 2.6.11

--- a/readme.md
+++ b/readme.md
@@ -11,13 +11,13 @@ Unfortunately, the official [openai](https://github.com/openai/openai-node) pack
 - You want a fast and small client that doesn't patch fetch
 - Supports all envs with native fetch: Node 18+, browsers, Deno, Cloudflare Workers, etc
 - Package size: `openai-fetch` is [~14kb](https://bundlephobia.com/package/openai-fetch) and `openai` is [~152kb](https://bundlephobia.com/package/openai)
-- You only need chat, completions, embeddings, and moderations
+- You only need chat, completions, embeddings, and moderations, and TTS
 
 ### Use the official `openai` package if:
 
 - Your runtime doesn't have native fetch support
 - Your app can't handle native ESM code
-- You need endpoints other than chat, completions, embeddings, and moderations
+- You need endpoints other than chat, completions, embeddings, and moderations, and TTS
 - You aren't concerned with lib size or fetch patching
 
 ## Install
@@ -42,7 +42,7 @@ The `apiKey` is optional and will be read from `process.env.OPENAI_API_KEY` if p
 
 ## API
 
-The API follows OpenAI very closely, so their [reference documentation](https://beta.openai.com/docs/api-reference) can generally be used. Everything is strongly typed, so you will know if anything is different as soon as TypeScript parses your code.
+The API follows OpenAI very closely, so their [reference documentation](https://platform.openai.com/docs/api-reference) can generally be used. Everything is strongly typed, so you will know if anything is different as soon as TypeScript parses your code.
 
 ```ts
 // Generate a single chat completion
@@ -62,6 +62,9 @@ client.createEmbeddings(params: EmbeddingParams): Promise<EmbeddingResponse>
 
 // Checks for potentially harmful content
 client.createModeration(params: ModerationParams): Promise<ModerationResponse>
+
+// Text-to-Speech
+client.createSpeech(params: SpeechParams): Promise<SpeechResponse>
 ```
 
 ### Type Definitions

--- a/src/openai-client.ts
+++ b/src/openai-client.ts
@@ -15,6 +15,8 @@ import {
   type EmbeddingResponse,
   type ModerationParams,
   type ModerationResponse,
+  type SpeechParams,
+  type SpeechResponse,
 } from './types.js';
 
 export type ConfigOpts = {
@@ -143,6 +145,17 @@ export class OpenAIClient {
     const response: OpenAI.ModerationCreateResponse = await this.getApi(opts)
       .post('moderations', { json: params })
       .json();
+    return response;
+  }
+
+  /** Generates audio from the input text. Also known as TTS. */
+  async createSpeech(
+    params: SpeechParams,
+    opts?: RequestOpts
+  ): Promise<SpeechResponse> {
+    const response = await this.getApi(opts)
+      .post('audio/speech', { json: params })
+      .arrayBuffer();
     return response;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,3 +86,6 @@ export type EmbeddingResponse = OpenAI.CreateEmbeddingResponse;
 
 export type ModerationParams = OpenAI.ModerationCreateParams;
 export type ModerationResponse = OpenAI.ModerationCreateResponse;
+
+export type SpeechParams = OpenAI.Audio.SpeechCreateParams;
+export type SpeechResponse = ArrayBuffer;


### PR DESCRIPTION
This PR adds support for OpenAI's TTS endpoint: https://platform.openai.com/docs/api-reference/audio/createSpeech?lang=node